### PR TITLE
Fix resultOnly typo in clear function

### DIFF
--- a/statistics.js
+++ b/statistics.js
@@ -91,7 +91,7 @@ module.exports = function(RED) {
                 case 'clear':
                     node.data =[];
                     saveData(value);
-                    if (node.resultsOnly) {
+                    if (node.resultOnly) {
                         return null;
                     }
                     break;


### PR DESCRIPTION
Extra 's' in `if (node.resultsOnly) {` causes the configuration to be ignored by the clear function.